### PR TITLE
Small typo fix for addins.dcf 

### DIFF
--- a/inst/rstudio/addins.dcf
+++ b/inst/rstudio/addins.dcf
@@ -1,4 +1,4 @@
 Name: packagefinder
-Description: Search packaes on CRAN.
+Description: Search packages on CRAN.
 Binding: packagefinderAddIn
 Interactive: true


### PR DESCRIPTION
Small typo that appears in the RStudio Addins menu - cheers, and thank you for this handy tool! 